### PR TITLE
Fixed logic bug in CommandImprovements.Hook.

### DIFF
--- a/ModComponents/CommandImprovements.cs
+++ b/ModComponents/CommandImprovements.cs
@@ -15,7 +15,7 @@ namespace BetterUI
         internal override void Hook()
         {
             if (mod.config.CommandResizeCommandWindow.Value ||
-                mod.config.SortingSortItemsScrapper.Value ||
+                mod.config.SortingSortItemsCommand.Value ||
                 mod.config.SortingSortItemsScrapper.Value)
             {
                 On.RoR2.UI.PickupPickerPanel.SetPickupOptions += PickupPickerPanel_SetPickupOptions;


### PR DESCRIPTION
ORing `mod.config.SortingSortItemsScrapper.Value` with itself seemed unproductive, so I took a guess at what the original intent was.