### PR TITLE
Initialize CommandImprovements.optionMap index 0 to -1

### DIFF
--- a/ModComponents/CommandImprovements.cs
+++ b/ModComponents/CommandImprovements.cs
@@ -39,6 +39,7 @@ namespace BetterUI
         {
             var maxOptions = Math.Max(ItemCatalog.itemCount, EquipmentCatalog.equipmentCount);
             optionMap = new int[maxOptions];
+            optionMap[0] = -1;
             availableIndex = new bool[maxOptions];
             sortedOptions = new PickupPickerController.Option[maxOptions];
         }


### PR DESCRIPTION
## Setup
* Command window resizing _disabled_
* Command item sorting _disabled_
* Scrapper item sorting _disabled_
* Command/Scrapper tooltips _enabled_ AND/OR Command/Scrapper item counters _enabled_

(This configuration disables the `CommandImprovements.PickupPickerPanel_SetPickupOptions` hook and enables the `CommandImprovements.PickupPickerPanel_OnCreateButton` hook.)

## Bug
Given the configuration described above, the user can only ever select the first item in the Command and Scrapper windows. All items have their usual icons, but all item tooltips will be for the first item.

## Blame
It was determined that this is caused by the 0th index of `CommandImprovements.optionMap` not being properly initialized. If we were using default settings, then `optionMap` would have been initialized by the `CommandImprovements.PickupPickerPanel_SetPickupOptions` hook.

The default C# array value is 0, which causes the first line of the `CommandImprovements.PickupPickerPanel_OnCreateButton` hook to always evaluate true:
```csharp
orig(self, optionMap[0] >= 0 ? optionMap[index] : index, button);
```

## Solution
Assign `-1` to the 0th index of `optionMap` in the `CommandImprovements.Start` function.