### PR TITLE
0 Second fix

### DIFF
--- a/Languages/UA.json
+++ b/Languages/UA.json
@@ -299,7 +299,7 @@
     "BETTERUI_PROCCOEFFICIENT": "Коофіцієнт проку",
     "BETTERUI_BASECOOLDOWN": "Базове перезаряджання",
     "BETTERUI_EFFECTIVECOOLDOWN": "Поточне перезаряджання",
-    "BETTERUI_SECOND": "секунду",
+    "BETTERUI_SECOND": "с",
     "BETTERUI_SECONDS": "секунд",
     "BETTERUI_BEFORE_SINGULAR": "До ({0} стеку): ",
     "BETTERUI_BEFORE_PLURAL": "До ({0} стеків): ",


### PR DESCRIPTION
So mod displays on 0 second - "BETTERUI_SECOND", but on Ukrainian we cant say 0 second, we're saying 0 seconds, so better just leave "с".